### PR TITLE
Remember User's Scroll Offset in the Dashboard View

### DIFF
--- a/lib/src/products_page/products_page_component.dart
+++ b/lib/src/products_page/products_page_component.dart
@@ -1,3 +1,4 @@
+import 'dart:html';
 import 'package:ngdart/angular.dart';
 import 'package:ngrouter/ngrouter.dart';
 import '/src/product_page/product.dart';
@@ -8,6 +9,22 @@ import '/src/product_page/product.dart';
   templateUrl: 'products_page_component.html',
   styleUrls: ['products_page_component.css'],
 )
-class ProductsPageComponent {
+class ProductsPageComponent implements OnActivate, OnDeactivate {
+  static const scrollYKey = 'scroll-y';
   static final products = List.generate(100, Product.new);
+
+  @override
+  void onDeactivate(RouterState current, RouterState next) {
+    // Save current scroll offset to local-storage.
+    window.localStorage[scrollYKey] = window.scrollY.toString();
+  }
+
+  @override
+  void onActivate(RouterState? previous, RouterState current) {
+    // Read scroll offset from local-storage.
+    final scrollY = int.tryParse(window.localStorage[scrollYKey] ?? '0');
+    
+    // Restore scroll position
+    window.requestAnimationFrame((_) => window.scrollTo(0, scrollY));    
+  }
 }


### PR DESCRIPTION
Persist the user’s scroll offset using local storage when they navigate away from the dashboard. Restore the scroll position when they return to the page